### PR TITLE
docs(progress): add Day 2 summary and learnings

### DIFF
--- a/progress/day2-summary.md
+++ b/progress/day2-summary.md
@@ -1,0 +1,63 @@
+# Day 2 – Summary
+
+**Date:** 2025-10-21  
+**Status:** ✅ Completed
+
+---
+
+## 🎯 Objectives
+- [x] Practice a disciplined Git workflow (feature branch → micro-commits → PR → squash merge)
+- [x] Refactor and style README with clear phases, structure, and usage
+- [x] Establish repo standards (PR template, commit guidelines, issue templates)
+- [x] Document outcomes and prepare for Day 3
+
+---
+
+## 🧩 Tasks Completed
+- **README**
+  - Refactored structure (phases, Phase 1 overview, repository layout, core tech, how to use)
+  - Added styling polish (icons/dividers) and improved scannability
+  - Fixed placeholders and verified links (Project Board, clone URL)
+  - Merged via **Squash & merge** (PR A)
+- **Repo standards**
+  - Added **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`)
+  - Added **Commit Guidelines** (`GIT_COMMIT_GUIDELINES.md`) incl. closing vs non-closing references
+  - Added **Issue templates** (`task.md`, `bug.md`, `standards.md`, `config.yml`)
+  - Added optional **.gitmessage** and usage instructions
+  - Merged via **Squash & merge** (PR B, Closes #17; Refs #2)
+- **Process**
+  - Prepared this **Day 2 summary** (PR C) to close the tracking issue (#2)
+
+---
+
+## 🛠️ Tools & Resources Used
+- Git & GitHub (feature branches, PRs, squash merges)
+- GitHub Projects (Issues ↔ PRs; To Do / Doing / Done)
+- IntelliJ IDEA, Markdown
+
+---
+
+## 🧠 Key Learnings / Insights
+- Keep commits **atomic**; separate content (`docs`) from presentation (`style`).
+- Put `Closes #id` in the **PR description** (or squash message) to be merge-strategy agnostic; use `Refs #id` for intermediate work.
+- Prefer **Squash & merge** for a clean, linear history; practice rebase locally to keep branches up-to-date.
+- Templates (PR/Issue) + commit guidelines reduce ambiguity and speed up reviews.
+- Safe rollback before publishing: `git reset --soft HEAD~1`.
+
+---
+
+## 🚀 Next Steps (Day 3 plan)
+- **Branching & sync practice:** create `feature/git-practice`, do 5 micro-commits, and practice `git pull --rebase` (compare with `git merge` locally for learning only).  
+- **Policy documentation:** add `GIT_GUIDELINES.md` (branch naming; rebase-preferred sync; **Squash & merge** policy; cleanup rules).  
+- **Licensing:** add **LICENSE** (MIT) in a tiny, separate PR.  
+- **Repository topics:** log a small task issue to set topics (e.g., `java`, `rest-api`, `sql`, `docker`, `spring-boot`) and complete it.
+
+---
+
+## 📂 Deliverables
+- ✅ Updated and styled `README.md`  
+- ✅ Standards added: PR template, commit guidelines, issue templates, `.gitmessage`  
+- ✅ PR A (README) merged; PR B (standards) merged  
+- ✅ This summary prepared (PR C) — use it to close **#2** after merge
+
+> _Reflection:_ Established a repeatable workflow: branch → micro-commits → PR (template) → squash merge → progress log. Standards now enforce consistency for all future work.


### PR DESCRIPTION
## Summary
Add Day 2 progress summary documenting today’s work and outcomes.

## Changes
- Add `progress/day2-summary.md` (objectives, tasks completed, insights, next steps)

## How to Test
1. Open `progress/day2-summary.md` and verify content renders correctly.
2. Confirm links and references are accurate (Project Board, related issues).

## Checklist
- [x] Scope is small and focused (atomic)
- [x] Commit messages follow convention
- [x] Docs updated (README / progress / others)
- [ ] Tests pass locally (N/A if docs-only)
- [ ] CI passes (when enabled)
- [x] No secrets or credentials included

## Risks & Rollback
- Risk level: Low
- Blast radius: `progress/day2-summary.md` only
- Rollback: revert this PR

## Related
- **Closes #2**
- Refs #17 