### PR TITLE
docs(license): add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ruben R.P.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Add an MIT License to clarify reuse and distribution terms for this public repository.

## Changes

* Add `LICENSE` (MIT) at the repo root with current year and author name

## How to Test

1. Open the `LICENSE` file in the repo root and verify:

   * Year is correct (2025)
   * Author is **Ruben R.P.**
   * License text matches MIT
2. Confirm GitHub recognizes the license (About panel shows “MIT License”).

## Checklist

* [x] Scope is small and focused (single file)
* [x] Commit messages follow convention
* [x] Docs updated (license added)
* [ ] Tests pass locally (N/A — docs only)
* [ ] CI passes (when enabled)
* [x] No secrets or credentials included

## Risks & Rollback

* Risk level: Low
* Blast radius: `LICENSE` only
* Rollback: revert this PR

## Related

* Refs #3
