### PR TITLE
fix(readme): update links and table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ mvn -B -ntp clean verify
 
 * **Phase 2 — Project Delivery (ResHub & StockBox)**
 
-    * **ResHub** (Hotel Reservation Manager) — main showcase project. 🔗 [ResHub](https://github.com/users/rubenrzprz/reshub)
+    * **ResHub** (Hotel Reservation Manager) — main showcase project. 🔗 [ResHub](https://github.com/rubenrzprz/reshub)
       Built with **Spring Boot + PostgreSQL** featuring:
 
         * JWT authentication & RBAC
@@ -270,9 +270,6 @@ mvn -B -ntp clean verify
 * **Day 8:** Dockerize app; local stack with `docker-compose`.
 * **Days 9–10:** CV, LinkedIn, portfolio polish (documentation and presentation).
 * **Days 11–14:** Basic CI with GitHub Actions; job materials; interview prep; Phase 2 plan.
-
-Track progress and daily execution on the Project Board: 🔗 Project Board — https://github.com/users/rubenrzprz/projects/2
-
 
 ## 📅 Phase 2 — 4-Week Overview
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Focused backend engineering growth — disciplined practice, traceable outcomes.
 11. [🔗 Useful Internal Docs](#-useful-internal-docs)
 12. [🗺️ Development Phases Overview](#-development-phases-overview)
 13. [📅 Phase 1 — 14-Day Overview](#-phase-1--14-day-overview)
-14. [🎯 Personal Mission Statement](#-personal-mission-statement)
-15. [👤 Author](#-author)
+14. [📅 Phase 2 — 4-Week Overview](#-phase-2--4-week-overview)
+15. [🎯 Personal Mission Statement](#-personal-mission-statement)
+16. [👤 Author](#-author)
 
 
 ---
@@ -231,7 +232,7 @@ mvn -B -ntp clean verify
 
 * **Phase 2 — Project Delivery (ResHub & StockBox)**
 
-    * **ResHub** (Hotel Reservation Manager) — main showcase project.
+    * **ResHub** (Hotel Reservation Manager) — main showcase project. 🔗 [ResHub](https://github.com/users/rubenrzprz/reshub)
       Built with **Spring Boot + PostgreSQL** featuring:
 
         * JWT authentication & RBAC


### PR DESCRIPTION
## Summary
Updated the table of contents and added a missing link to ResHub project.

## Changes
- Update table of contents (sections 1-16)
- Add link to [ResHub repository](https://github.com/rubenrzprz/reshub)

## How to Test
1. Open README.md and verify:
   * The links from the table of contents work to the proper sections.
   * The link to the ResHub repository works.
  
## Checklist
- [x] Scope is small and focused (atomic)
- [x] Commit messages follow convention
- [x] Docs updated (README)
- [x] Tests pass locally (N/A)
- [x] CI passes (when enabled)
- [x] No secrets or credentials included

## Risks & Rollback
- Risk level: Low
- Blast radius: `README.md` only
- Rollback: revert this PR